### PR TITLE
chore(codeowners): move CODEOWNERS to .github directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @BonnierNews/bn-gem-inlogg

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @BonnierNews/bn-open-source


### PR DESCRIPTION
Relocated the CODEOWNERS file from the repository root to the .github directory to follow GitHub's recommended structure. Updated the owner from @BonnierNews/bn-open-source to @BonnierNews/bn-gem-inlogg.