### PR TITLE
feat(types): add AuthOptions type and update config usage

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,6 @@
 export { auth } from "./lib/auth";
 export type {
+  AuthOptions,
   LoginOptions,
   LogoutOptions,
-  OidcClient,
-  OidcClientConfig,
 } from "./lib/types";

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -14,13 +14,17 @@ import {
   requestContext,
   idToken,
 } from "./middleware";
-import {
+import type {
+  AuthOptions,
   OidcClientConfig,
   OidcConfig,
   OidcWellKnownConfig,
 } from "./types";
 
-const defaults: Partial<OidcClientConfig> = {
+const defaultConfig: OidcClientConfig = {
+  clientId: "",
+  issuerBaseURL: new URL("https://example.com"),
+  baseURL: new URL("https://example.com"),
   loginPath: "/id/login",
   logoutPath: "/id/logout",
   loginCallbackPath: "/id/login/callback",
@@ -52,12 +56,15 @@ const configSchema = Joi.object({
 }).required();
 
 /**
- * Express middleware to be used to connect to Bonnier News OIDC provider and
- * register required routes.
+ * Express middleware to be used to connect to Bonnier News OIDC provider
+ * and register required routes.
  */
-function auth(config: OidcClientConfig): Router {
-  const clientConfig = { ...defaults, ...config };
-  let wellKnownConfig: OidcWellKnownConfig | null = null;
+function auth(options: AuthOptions): Router {
+  const clientConfig = {
+    ...defaultConfig,
+    ...options,
+  };
+  let wellKnownConfig: OidcWellKnownConfig;
   let signingKeys: SigningKey[];
 
   const validation = configSchema.validate(clientConfig);
@@ -69,7 +76,7 @@ function auth(config: OidcClientConfig): Router {
 
   const getConfig = (): OidcConfig => ({
     clientConfig,
-    wellKnownConfig: wellKnownConfig!,
+    wellKnownConfig,
     signingKeys,
   });
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -16,28 +16,31 @@ type LogoutOptions = {
   returnUri?: string;
 };
 
-// TODO: Create a type for the OIDC client configuration options sent in by the client
-//       and let this "complete" type extend it. That way, we only need to have truly
-//       optional properties as optional (like cookieDomainURL).
 type OidcClientConfig = {
   clientId: string;
   clientSecret?: string;
   issuerBaseURL: URL;
   baseURL: URL;
-  loginPath?: string; // Path to the login endpoint, defaults to "/id/login"
-  loginCallbackPath?: string; // Path to the login callback endpoint, defaults to "/id/login/callback"
-  logoutCallbackPath?: string; // Path to the logout callback endpoint, defaults to "/id/logout/callback"
-  logoutPath?: string; // Path to the logout endpoint, defaults to "/id/logout"
+  loginPath: string; // Path to the login endpoint, defaults to "/id/login"
+  loginCallbackPath: string; // Path to the login callback endpoint, defaults to "/id/login/callback"
+  logoutPath: string; // Path to the logout endpoint, defaults to "/id/logout"
+  logoutCallbackPath: string; // Path to the logout callback endpoint, defaults to "/id/logout/callback"
   cookieDomainURL?: URL; // Domain where cookies should be set. TODO: Should this be forced?
   locale?: string; // Locale to override the OIDC provider app default locale
-  scopes?: string[]; // Scopes to request during login, defaults to ["openid", "profile", "email", "entitlements", "offline_access"]
-  prompts?: string[]; // Custom prompts to add to the login request
-  cookies?: {
+  scopes: string[]; // Scopes to request during login, defaults to ["openid", "profile", "email", "entitlements", "offline_access"]
+  prompts: string[]; // Custom prompts to add to the login request
+  cookies: {
     authParams: string,
     tokens: string,
     logout: string,
   }
 };
+
+type AuthOptions = Partial<OidcClientConfig> & {
+  clientId: string;
+  issuerBaseURL: URL;
+  baseURL: URL;
+}
 
 type OidcWellKnownConfig = {
   issuer: string;
@@ -79,7 +82,7 @@ type OidcClient = {
   idToken?: string;
   expiresIn?: number;
   idTokenClaims?: Record<string, any>;
-  isAuthenticated?: boolean;
+  isAuthenticated: boolean;
 };
 
 declare module "express-serve-static-core" {
@@ -89,6 +92,7 @@ declare module "express-serve-static-core" {
 }
 
 export type {
+  AuthOptions,
   LoginOptions,
   LogoutOptions,
   OidcClient,

--- a/test/helpers/app-helper.ts
+++ b/test/helpers/app-helper.ts
@@ -1,6 +1,6 @@
 import express from "express";
 
-import { auth, type OidcClientConfig } from "../../index";
+import { auth, type AuthOptions } from "../../index";
 
 const createApp = () => {
   const app = express();
@@ -8,7 +8,7 @@ const createApp = () => {
   return app;
 };
 
-const createAppWithMiddleware = (clientConfig: OidcClientConfig) => {
+const createAppWithMiddleware = (clientConfig: AuthOptions) => {
   const app = createApp();
   app.use(auth(clientConfig));
   return app;

--- a/test/unit/setup.unit.ts
+++ b/test/unit/setup.unit.ts
@@ -62,7 +62,17 @@ Feature("Setup", () => {
           clientId,
           issuerBaseURL: new URL(issuerBaseURL),
           baseURL: new URL(baseURL),
+          loginPath: "/id/login",
+          loginCallbackPath: "/id/login/callback",
+          logoutPath: "/id/logout",
+          logoutCallbackPath: "/id/logout/callback",
           scopes: [ "profile", "email", "entitlements", "offline_access" ],
+          prompts: [],
+          cookies: {
+            authParams: "bnoidcauthparams",
+            tokens: "bnoidctokens",
+            logout: "bnoidclogout",
+          },
         });
       } catch (error) {
         initializationError = error as Error;


### PR DESCRIPTION
Introduce `AuthOptions` as a partial version of `OidcClientConfig` with required core fields, allowing more flexible configuration. Update `auth` middleware and related helpers to accept `AuthOptions` instead of `OidcClientConfig`. Make config defaults explicit and required fields non-optional in `OidcClientConfig`. Update tests and type exports to reflect these changes.