### PR TITLE
refactor: rename returnUri to returnPath for logout flow

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -100,13 +100,11 @@ function auth(config: OidcClientConfig): Router {
   router.use(queryParams);
 
   router.get(clientConfig.loginPath as string, (req: Request, res: Response) => {
-    // TODO: Remove fallback returnUri and get it from config in the login handler
-    req.oidc.login(req, res, { returnUri: req.query["return-uri"] as string ?? "/" });
+    req.oidc.login(req, res, req.query["return-path"] ? { returnPath: req.query["return-path"] as string } : {});
   });
 
   router.get(clientConfig.logoutPath as string, (req: Request, res: Response) => {
-    // TODO: Remove fallback returnUri and get it from config in the login handler
-    req.oidc.logout(req, res, { returnUri: req.query["return-uri"] as string ?? "/" });
+    req.oidc.logout(req, res, req.query["return-path"] ? { returnPath: req.query["return-path"] as string } : {});
   });
 
   router.get(clientConfig.loginCallbackPath as string, (req: Request, res: Response) => {

--- a/lib/handlers/login-callback.ts
+++ b/lib/handlers/login-callback.ts
@@ -13,7 +13,7 @@ async function loginCallback(
   const { clientConfig, wellKnownConfig, signingKeys } = req.oidc.config;
   const { state: incomingState, code } = req.query as { state: string; code: string };
   const { state: storedState, codeVerifier } = req.cookies.bnoidcauthparams ?? {};
-  const returnUri = req.query["return-uri"] ?? "/";
+  const returnPath = req.query["return-path"] ?? "/";
 
   try {
     if (incomingState !== storedState) {
@@ -45,7 +45,7 @@ async function loginCallback(
     unsetAuthParamsCookie(clientConfig, res);
   }
 
-  res.redirect(returnUri as string);
+  res.redirect(returnPath as string);
 }
 
 export { loginCallback };

--- a/lib/handlers/login.ts
+++ b/lib/handlers/login.ts
@@ -27,7 +27,7 @@ function login(
 
   const redirectUri = new URL(clientConfig.baseURL.toString());
   redirectUri.pathname = clientConfig.loginCallbackPath as string;
-  redirectUri.searchParams.set("return-uri", options.returnUri ?? "/");
+  redirectUri.searchParams.set("return-path", options.returnPath ?? "/");
 
   const state = generateState();
   const nonce = generateNonce();

--- a/lib/handlers/logout-callback.ts
+++ b/lib/handlers/logout-callback.ts
@@ -12,13 +12,13 @@ function logoutCallback(
 
   unsetLogoutCookie(clientConfig, res);
 
-  let returnUri = req.query["return-uri"] ?? "/";
+  let returnPath = req.query["return-path"] ?? "/";
 
   if (incomingState && incomingState !== storedState?.state) {
-    returnUri = "/";
+    returnPath = "/";
   }
 
-  res.redirect(returnUri as string);
+  res.redirect(returnPath as string);
 }
 
 export { logoutCallback };

--- a/lib/handlers/logout.ts
+++ b/lib/handlers/logout.ts
@@ -17,7 +17,7 @@ function logout(
   const { clientConfig, wellKnownConfig } = req.oidc.config;
   const redirectUri = new URL(clientConfig.baseURL.toString());
   redirectUri.pathname = clientConfig.logoutCallbackPath as string;
-  redirectUri.searchParams.set("return-uri", options.returnUri ?? "/");
+  redirectUri.searchParams.set("return-path", options.returnPath ?? "/");
 
   const tokenSet = getTokensCookie(clientConfig, req);
   const state = generateState();

--- a/lib/middleware/id-token.ts
+++ b/lib/middleware/id-token.ts
@@ -17,7 +17,7 @@ async function idToken(req: Request, res: Response, next: NextFunction) {
         await req.oidc.refresh(req, res);
       } catch (refreshError) {
         // If the refresh fails, redirect to login
-        req.oidc.login(req, res, { returnUri: req.originalUrl });
+        req.oidc.login(req, res, { returnPath: req.originalUrl });
 
         return;
       }

--- a/lib/middleware/query-params.ts
+++ b/lib/middleware/query-params.ts
@@ -8,7 +8,7 @@ async function queryParams(req: Request, res: Response, next: NextFunction) {
 
     // TODO: Add support for login token
     req.oidc.login(req, res, {
-      returnUri: searchParams.size > 0 ? `${req.path}?${searchParams}` : req.path,
+      returnPath: searchParams.size > 0 ? `${req.path}?${searchParams}` : req.path,
       prompts: idlogin === "silent" ? [ "none" ] : [],
     });
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -2,7 +2,7 @@ import type { Request as ExpressRequest, Response } from "express";
 import type { SigningKey } from "jwks-rsa";
 
 type LoginOptions = {
-  returnUri?: string;
+  returnPath?: string;
   scopes?: string[];
   prompts?: string[];
 };
@@ -13,7 +13,7 @@ type VerifyOptions = {
 };
 
 type LogoutOptions = {
-  returnUri?: string;
+  returnPath?: string;
 };
 
 // TODO: Create a type for the OIDC client configuration options sent in by the client

--- a/lib/utils/jwt.ts
+++ b/lib/utils/jwt.ts
@@ -21,7 +21,6 @@ function verifyJwt(token: string, signingKeys: SigningKey[], options: VerifyOpti
   }
 
   return false;
-  // throw new Error("Failed to verify ID token with any of the provided keys");
 }
 
 function decodeJwt(token: string, signingKeys: SigningKey[], options: VerifyOptions): any {

--- a/test/feature/login.feature.ts
+++ b/test/feature/login.feature.ts
@@ -63,7 +63,7 @@ Feature("Login", () => {
     });
 
     When("user requests the login endpoint", async () => {
-      loginResponse = await request(app).get("/id/login?return-uri=%2Ftest");
+      loginResponse = await request(app).get("/id/login?return-path=%2Ftest");
       cookies = loginResponse.header["set-cookie"];
     });
 
@@ -75,7 +75,7 @@ Feature("Login", () => {
       expect(queryParams.client_id).to.equal("test-client-id");
       expect(queryParams.response_type).to.equal("code");
       expect(queryParams.scope).to.equal("openid profile email entitlements offline_access");
-      expect(queryParams.redirect_uri).to.equal(`${baseURL}/id/login/callback?return-uri=%2Ftest`);
+      expect(queryParams.redirect_uri).to.equal(`${baseURL}/id/login/callback?return-path=%2Ftest`);
       expect(queryParams.state).to.exist;
       expect(queryParams.nonce).to.exist;
 
@@ -139,7 +139,7 @@ Feature("Login", () => {
       expect(queryParams.client_id).to.equal("test-client-id");
       expect(queryParams.response_type).to.equal("code");
       expect(queryParams.scope).to.equal("openid profile email entitlements offline_access");
-      expect(queryParams.redirect_uri).to.equal(`${baseURL}/id/login/callback?return-uri=%2Fsome-path%3FotherParam%3Dvalue`);
+      expect(queryParams.redirect_uri).to.equal(`${baseURL}/id/login/callback?return-path=%2Fsome-path%3FotherParam%3Dvalue`);
       expect(queryParams.state).to.exist;
       expect(queryParams.nonce).to.exist;
 

--- a/test/feature/logout.feature.ts
+++ b/test/feature/logout.feature.ts
@@ -63,7 +63,7 @@ Feature("Logout", () => {
     });
 
     When("user navigates to /id/logout", async () => {
-      logoutResponse = await request(app).get("/id/logout?return-uri=%2Ftest")
+      logoutResponse = await request(app).get("/id/logout?return-path=%2Ftest")
         .set("Cookie", cookieString);
     });
 
@@ -73,7 +73,7 @@ Feature("Logout", () => {
       expect(locationUrl.origin).to.equal(issuerBaseURL);
       expect(locationUrl.pathname).to.equal("/oauth/logout");
       expect(locationUrl.searchParams.get("client_id")).to.equal(clientId);
-      expect(locationUrl.searchParams.get("post_logout_redirect_uri")).to.equal(`${baseURL}/id/logout/callback?return-uri=%2Ftest`);
+      expect(locationUrl.searchParams.get("post_logout_redirect_uri")).to.equal(`${baseURL}/id/logout/callback?return-path=%2Ftest`);
     });
 
     let parsedSetCookieHeader: Record<string, any>;
@@ -94,7 +94,7 @@ Feature("Logout", () => {
 
     When("OIDC provider redirects back to the callback endpoint with incorrect state", async () => {
       callbackResponse = await request(app)
-        .get("/id/logout/callback?return-uri=%2Ftest&state=incorrect-state")
+        .get("/id/logout/callback?return-path=%2Ftest&state=incorrect-state")
         .set("Cookie", cookies);
     });
 
@@ -108,7 +108,7 @@ Feature("Logout", () => {
 
     When("OIDC provider redirects back to the callback endpoint", async () => {
       callbackResponse = await request(app)
-        .get(`/id/logout/callback?return-uri=%2Ftest&state=${state}`)
+        .get(`/id/logout/callback?return-path=%2Ftest&state=${state}`)
         .set("Cookie", cookies);
     });
 


### PR DESCRIPTION
Standardize the naming of redirect parameters by replacing all instances of `returnUri` with `returnPath` in the logout callback handler and related code. This improves consistency across the authentication and logout flows, aligning with recent changes in login and middleware handlers. Updates include handler logic, middleware, types, and tests.