### PR TITLE
refactor: rename returnPath to returnTo in OIDC flow

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -62,7 +62,7 @@ const configSchema = Joi.object({
  * and register required routes.
  */
 function auth(options: AuthOptions): Router {
-  const clientConfig = {
+  const clientConfig: OidcClientConfig = {
     ...defaultConfig,
     ...options,
   };
@@ -108,19 +108,19 @@ function auth(options: AuthOptions): Router {
   router.use(idToken);
   router.use(queryParams);
 
-  router.get(clientConfig.loginPath as string, (req: Request, res: Response) => {
-    res.oidc.login(req, res, req.query["return-path"] ? { returnPath: req.query["return-path"] as string } : {});
+  router.get(clientConfig.loginPath, (req: Request, res: Response) => {
+    res.oidc.login(req, res, req.query["return-to"] ? { returnTo: req.query["return-to"] as string } : {});
   });
 
-  router.get(clientConfig.logoutPath as string, (req: Request, res: Response) => {
-    res.oidc.logout(req, res, req.query["return-path"] ? { returnPath: req.query["return-path"] as string } : {});
+  router.get(clientConfig.logoutPath, (req: Request, res: Response) => {
+    res.oidc.logout(req, res, req.query["return-to"] ? { returnTo: req.query["return-to"] as string } : {});
   });
 
-  router.get(clientConfig.loginCallbackPath as string, (req: Request, res: Response) => {
+  router.get(clientConfig.loginCallbackPath, (req: Request, res: Response) => {
     res.oidc.loginCallback(req, res);
   });
 
-  router.get(clientConfig.logoutCallbackPath as string, (req: Request, res: Response) => {
+  router.get(clientConfig.logoutCallbackPath, (req: Request, res: Response) => {
     res.oidc.logoutCallback(req, res);
   });
 

--- a/lib/handlers/login-callback.ts
+++ b/lib/handlers/login-callback.ts
@@ -14,7 +14,7 @@ async function loginCallback(
   const { clientConfig, wellKnownConfig, signingKeys } = req.oidc.config;
   const { state: incomingState, code } = req.query as { state: string; code: string };
   const { state: storedState, codeVerifier } = req.cookies.bnoidcauthparams ?? {};
-  const returnPath: string = req.query["return-path"] as string ?? clientConfig.baseURL.pathname;
+  const returnTo: string = req.query["return-to"] as string ?? clientConfig.baseURL.pathname;
 
   try {
     if (incomingState !== storedState) {
@@ -23,7 +23,7 @@ async function loginCallback(
 
     const redirectUri = new URL(clientConfig.baseURL.toString());
     redirectUri.pathname = clientConfig.loginCallbackPath;
-    redirectUri.searchParams.set("return-path", returnPath);
+    redirectUri.searchParams.set("return-to", returnTo);
 
     const params : FetchTokensByAuthorizationCodeOptions = {
       tokenEndpoint: wellKnownConfig.token_endpoint,
@@ -60,7 +60,7 @@ async function loginCallback(
     unsetAuthParamsCookie(clientConfig, res);
   }
 
-  res.redirect(returnPath as string);
+  res.redirect(returnTo);
 }
 
 export { loginCallback };

--- a/lib/handlers/login.ts
+++ b/lib/handlers/login.ts
@@ -21,7 +21,7 @@ function login(
 
   const redirectUri = new URL(clientConfig.baseURL.toString());
   redirectUri.pathname = `${redirectUri.pathname.replace(/\/$/, "")}${clientConfig.loginCallbackPath}`;
-  redirectUri.searchParams.set("return-path", options.returnPath ?? clientConfig.baseURL.pathname);
+  redirectUri.searchParams.set("return-to", options.returnTo ?? clientConfig.baseURL.pathname);
 
   const state = generateState();
   const nonce = generateNonce();

--- a/lib/handlers/logout-callback.ts
+++ b/lib/handlers/logout-callback.ts
@@ -12,13 +12,13 @@ function logoutCallback(
 
   unsetLogoutCookie(clientConfig, res);
 
-  let returnPath = req.query["return-path"] ?? "/";
+  let returnTo: string = req.query["return-to"] as string ?? "/";
 
   if (incomingState && incomingState !== storedState?.state) {
-    returnPath = "/";
+    returnTo = "/";
   }
 
-  res.redirect(returnPath as string);
+  res.redirect(returnTo);
 }
 
 export { logoutCallback };

--- a/lib/handlers/logout.ts
+++ b/lib/handlers/logout.ts
@@ -17,7 +17,7 @@ function logout(
   const { clientConfig, wellKnownConfig } = req.oidc.config;
   const redirectUri = new URL(clientConfig.baseURL.toString());
   redirectUri.pathname = `${redirectUri.pathname.replace(/\/$/, "")}${clientConfig.logoutCallbackPath}`;
-  redirectUri.searchParams.set("return-path", options.returnPath ?? clientConfig.baseURL.pathname);
+  redirectUri.searchParams.set("return-to", options.returnTo ?? clientConfig.baseURL.pathname);
 
   const tokenSet = getTokensCookie(clientConfig, req);
   const state = generateState();

--- a/lib/middleware/id-token.ts
+++ b/lib/middleware/id-token.ts
@@ -27,7 +27,7 @@ async function idToken(req: Request, res: Response, next: NextFunction) {
         throw new Error("Failed to decode ID token after refresh");
       }
     } catch (error) {
-      res.oidc.login(req, res, { returnPath: req.originalUrl });
+      res.oidc.login(req, res, { returnTo: req.originalUrl });
 
       return;
     }

--- a/lib/middleware/query-params.ts
+++ b/lib/middleware/query-params.ts
@@ -8,7 +8,7 @@ async function queryParams(req: Request, res: Response, next: NextFunction) {
 
     // TODO: Add support for login token
     res.oidc.login(req, res, {
-      returnPath: searchParams.size > 0 ? `${req.path}?${searchParams}` : req.path,
+      returnTo: searchParams.size > 0 ? `${req.path}?${searchParams}` : req.path,
       prompts: idlogin === "silent" ? [ "none" ] : [],
     });
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -2,7 +2,7 @@ import type { Request as ExpressRequest, Response as ExpressResponse } from "exp
 import type { SigningKey } from "jwks-rsa";
 
 type LoginOptions = {
-  returnPath?: string;
+  returnTo?: string;
   scopes?: string[];
   prompts?: string[];
   locale?: string;
@@ -14,7 +14,7 @@ type VerifyOptions = {
 };
 
 type LogoutOptions = {
-  returnPath?: string;
+  returnTo?: string;
 };
 
 type OidcClientConfig = {

--- a/test/feature/login.feature.ts
+++ b/test/feature/login.feature.ts
@@ -65,7 +65,7 @@ Feature("Login", () => {
     });
 
     When("user requests the login endpoint", async () => {
-      loginResponse = await request(app).get("/id/login?return-path=%2Ftest");
+      loginResponse = await request(app).get("/id/login?return-to=%2Ftest");
       cookies = loginResponse.header["set-cookie"];
     });
 
@@ -77,7 +77,7 @@ Feature("Login", () => {
       expect(queryParams.client_id).to.equal("test-client-id");
       expect(queryParams.response_type).to.equal("code");
       expect(queryParams.scope).to.equal("openid profile email entitlements offline_access");
-      expect(queryParams.redirect_uri).to.equal(`${baseURL}/id/login/callback?return-path=%2Ftest`);
+      expect(queryParams.redirect_uri).to.equal(`${baseURL}/id/login/callback?return-to=%2Ftest`);
       expect(queryParams.state).to.exist;
       expect(queryParams.nonce).to.exist;
 
@@ -141,7 +141,7 @@ Feature("Login", () => {
       expect(queryParams.client_id).to.equal("test-client-id");
       expect(queryParams.response_type).to.equal("code");
       expect(queryParams.scope).to.equal("openid profile email entitlements offline_access");
-      expect(queryParams.redirect_uri).to.equal(`${baseURL}/id/login/callback?return-path=%2Fsome-path%3FotherParam%3Dvalue`);
+      expect(queryParams.redirect_uri).to.equal(`${baseURL}/id/login/callback?return-to=%2Fsome-path%3FotherParam%3Dvalue`);
       expect(queryParams.state).to.exist;
       expect(queryParams.nonce).to.exist;
 

--- a/test/feature/logout.feature.ts
+++ b/test/feature/logout.feature.ts
@@ -63,7 +63,7 @@ Feature("Logout", () => {
     });
 
     When("user navigates to /id/logout", async () => {
-      logoutResponse = await request(app).get("/id/logout?return-path=%2Ftest")
+      logoutResponse = await request(app).get("/id/logout?return-to=%2Ftest")
         .set("Cookie", cookieString);
     });
 
@@ -73,7 +73,7 @@ Feature("Logout", () => {
       expect(locationUrl.origin).to.equal(issuerBaseURL);
       expect(locationUrl.pathname).to.equal("/oauth/logout");
       expect(locationUrl.searchParams.get("client_id")).to.equal(clientId);
-      expect(locationUrl.searchParams.get("post_logout_redirect_uri")).to.equal(`${baseURL}/id/logout/callback?return-path=%2Ftest`);
+      expect(locationUrl.searchParams.get("post_logout_redirect_uri")).to.equal(`${baseURL}/id/logout/callback?return-to=%2Ftest`);
     });
 
     let parsedSetCookieHeader: Record<string, any>;
@@ -94,7 +94,7 @@ Feature("Logout", () => {
 
     When("OIDC provider redirects back to the callback endpoint with incorrect state", async () => {
       callbackResponse = await request(app)
-        .get("/id/logout/callback?return-path=%2Ftest&state=incorrect-state")
+        .get("/id/logout/callback?return-to=%2Ftest&state=incorrect-state")
         .set("Cookie", cookies);
     });
 
@@ -108,7 +108,7 @@ Feature("Logout", () => {
 
     When("OIDC provider redirects back to the callback endpoint", async () => {
       callbackResponse = await request(app)
-        .get(`/id/logout/callback?return-path=%2Ftest&state=${state}`)
+        .get(`/id/logout/callback?return-to=%2Ftest&state=${state}`)
         .set("Cookie", cookies);
     });
 


### PR DESCRIPTION
This change standardizes the query parameter and option name from `returnPath` to `returnTo` throughout the OIDC authentication since the string can be a complete URL, not just a path. Updates include all relevant middleware, handlers, types, and tests to ensure consistency and clarity in parameter naming.