### PR TITLE
fix(cookies): only set refresh token cookie if present

### DIFF
--- a/lib/handlers/login-callback.ts
+++ b/lib/handlers/login-callback.ts
@@ -2,7 +2,7 @@ import type { NextFunction, Request, Response } from "express";
 
 import type { TokenSet } from "../types";
 import { InvalidStateError, InvalidIdTokenError } from "../errors";
-import { setTokensCookie, unsetAuthParamsCookie } from "../utils/cookies";
+import { setTokenCookies, unsetAuthParamsCookie } from "../utils/cookies";
 import { verifyJwt } from "../utils/jwt";
 import { fetchTokensByAuthorizationCode, FetchTokensByAuthorizationCodeOptions } from "../utils/tokens";
 
@@ -51,7 +51,7 @@ async function loginCallback(
       throw new InvalidIdTokenError("Failed to verify ID token");
     }
 
-    setTokensCookie(clientConfig, res, tokens);
+    setTokenCookies(clientConfig, res, tokens);
   } catch (error) {
     next(error);
 

--- a/lib/handlers/logout.ts
+++ b/lib/handlers/logout.ts
@@ -5,7 +5,7 @@ import {
   getTokensCookie,
   setLogoutCookie,
   unsetAuthParamsCookie,
-  unsetTokensCookie,
+  unsetTokenCookies,
 } from "../utils/cookies";
 import { generateState } from "../utils/crypto";
 
@@ -35,7 +35,7 @@ function logout(
   setLogoutCookie(clientConfig, res, { state });
 
   unsetAuthParamsCookie(clientConfig, res);
-  unsetTokensCookie(clientConfig, res);
+  unsetTokenCookies(clientConfig, res);
 
   const authorizationUrl = new URL(wellKnownConfig.end_session_endpoint);
   authorizationUrl.search = params.toString();

--- a/lib/middleware/id-token.ts
+++ b/lib/middleware/id-token.ts
@@ -3,6 +3,7 @@ import type { Request, Response, NextFunction } from "express";
 import type { OidcRequestContext } from "../types";
 import { decodeJwt } from "../utils/jwt";
 
+// @todo This middleware should not be run for the login callback route!
 async function idToken(req: Request, res: Response, next: NextFunction) {
   if (!req.oidc.idToken) {
     next();
@@ -18,6 +19,7 @@ async function idToken(req: Request, res: Response, next: NextFunction) {
 
   if (!decodedJwt) {
     try {
+      // @todo We have to check if a refresh token exists
       await res.oidc.refresh(req, res);
 
       // Decode the new ID token again after refresh

--- a/lib/utils/cookies.ts
+++ b/lib/utils/cookies.ts
@@ -32,7 +32,7 @@ function unsetAuthParamsCookie(
   });
 }
 
-function setTokensCookie(
+function setTokenCookies(
   { baseURL, cookieDomainURL, cookies }: OidcClientConfig,
   res: Response,
   tokens: TokenSet
@@ -43,12 +43,6 @@ function setTokensCookie(
     domain: cookieDomain.hostname,
     secure: cookieDomain.protocol === "https:",
     expires: new Date(Date.now() + 1000 * tokens.expiresIn),
-  });
-
-  setCookie(res, cookies.tokens.refresh, tokens.refreshToken, {
-    domain: cookieDomain.hostname,
-    secure: cookieDomain.protocol === "https:",
-    expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30), // 30 days
   });
 
   setCookie(res, cookies.tokens.id, tokens.idToken, {
@@ -62,9 +56,17 @@ function setTokensCookie(
     secure: cookieDomain.protocol === "https:",
     expires: new Date(Date.now() + 1000 * tokens.expiresIn),
   });
+
+  if (tokens.refreshToken) {
+    setCookie(res, cookies.tokens.refresh, tokens.refreshToken, {
+      domain: cookieDomain.hostname,
+      secure: cookieDomain.protocol === "https:",
+      expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30), // 30 days
+    });
+  }
 }
 
-function unsetTokensCookie(
+function unsetTokenCookies(
   { baseURL, cookieDomainURL, cookies }: OidcClientConfig,
   res: Response
 ): void {
@@ -166,8 +168,8 @@ export {
   getTokensCookie,
   setAuthParamsCookie,
   setLogoutCookie,
-  setTokensCookie,
+  setTokenCookies,
   unsetAuthParamsCookie,
   unsetLogoutCookie,
-  unsetTokensCookie,
+  unsetTokenCookies,
 };

--- a/lib/utils/refresh.ts
+++ b/lib/utils/refresh.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from "express";
 
 import { RefreshRequestError } from "../errors";
-import { setTokensCookie } from "./cookies";
+import { setTokenCookies } from "./cookies";
 import { verifyJwt } from "./jwt";
 import { fetchTokensByRefreshToken, FetchTokensByRefreshTokenOptions } from "./tokens";
 
@@ -39,7 +39,7 @@ async function refreshTokens(
       throw new Error("Failed to verify ID token");
     }
 
-    setTokensCookie(clientConfig, res, tokens);
+    setTokenCookies(clientConfig, res, tokens);
 
     // Update the request context with new tokens
     req.oidc.accessToken = tokens.accessToken;


### PR DESCRIPTION
Update setTokenCookies to set the refresh token cookie only when a refresh token is present, which occurs if the offline_access scope was requested. Renames related functions for clarity and updates all references.