### PR TITLE
feat: support bypass_cache on token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ The middleware adds an `oidc` property to the Express `Response` object with aut
 | `loginCallback` | `(req, res) => void` | Handles login callback |
 | `logout` | `(req, res, options?) => void` | Initiates logout flow |
 | `logoutCallback` | `(req, res) => void` | Handles logout callback |
-| `refresh` | `(req, res) => Promise<void>` | Refreshes tokens |
+| `refresh` | `(req, res, options?) => Promise<void>` | Refreshes tokens |
 
 ### Login Options
 
@@ -316,6 +316,14 @@ type LoginOptions = {
 ```typescript
 type LogoutOptions = {
   returnTo?: string;     // URL to redirect after logout
+}
+```
+
+### Refresh Options
+
+```typescript
+type RefreshOptions = {
+  bypassCache?: boolean; // Ask the OIDC provider to bypass its user/entitlements cache when issuing new tokens
 }
 ```
 
@@ -361,6 +369,16 @@ GET /some-page?idrefresh=true
 ```
 
 This is useful in scenarios where claims or entitlements may have changed during the user's session—such as after a purchase, subscription upgrade, or profile update—allowing the application to refresh tokens and retrieve updated user information without requiring the user to log in again.
+
+#### `idbypasscache`
+
+Used together with `idrefresh` to ask the OIDC provider to bypass its user/entitlements cache and fetch fresh data from its upstream sources when issuing the new tokens:
+
+```
+GET /some-page?idrefresh=true&idbypasscache=true
+```
+
+Without this parameter the provider may serve claims from its cache, so a plain refresh is not guaranteed to pick up upstream changes immediately. Use sparingly—bypassing the cache adds load on the provider's upstream services.
 
 ### Authentication Flow
 

--- a/lib/middleware/oidc-context.ts
+++ b/lib/middleware/oidc-context.ts
@@ -31,7 +31,7 @@ function oidcContext(getConfig: () => OidcConfig) {
       loginCallback: (request, response) => loginCallback(request, response, next),
       logout: (request, response, options) => logout(request, response, options),
       logoutCallback: (request, response) => logoutCallback(request, response),
-      refresh: async (request, response) => await refreshTokens(request, response),
+      refresh: async (request, response, options) => await refreshTokens(request, response, options),
     };
 
     next();

--- a/lib/middleware/query-params.ts
+++ b/lib/middleware/query-params.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 
 async function queryParams(req: Request, res: Response, next: NextFunction) {
-  const { idlogin, idrefresh, idlogintoken, ...queryParameters } = req.query as Record<string, string>;
+  const { idlogin, idrefresh, idlogintoken, idbypasscache, ...queryParameters } = req.query as Record<string, string>;
 
   if (idlogintoken) {
     const searchParams = new URLSearchParams(queryParameters);
@@ -28,7 +28,7 @@ async function queryParams(req: Request, res: Response, next: NextFunction) {
 
   if (idrefresh) {
     try {
-      await res.oidc.refresh(req, res);
+      await res.oidc.refresh(req, res, { bypassCache: idbypasscache === "true" });
     } catch (error) { // eslint-disable-line @typescript-eslint/no-unused-vars
       // TODO: Should this be handled or just continue?
     }

--- a/lib/middleware/query-params.ts
+++ b/lib/middleware/query-params.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction } from "express";
+import type { Request, Response, NextFunction } from "express";
 
 async function queryParams(req: Request, res: Response, next: NextFunction) {
   const { idlogin, idrefresh, idlogintoken, idbypasscache, ...queryParameters } = req.query as Record<string, string>;

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -18,6 +18,10 @@ type LogoutOptions = {
   returnTo?: string;
 };
 
+type RefreshOptions = {
+  bypassCache?: boolean; // Ask the OIDC provider to bypass its user/entitlements cache when issuing new tokens
+};
+
 type OidcClientConfig = {
   clientId: string;
   clientSecret?: string;
@@ -96,7 +100,7 @@ type OidcResponseContext = {
   loginCallback: (req: ExpressRequest, res: ExpressResponse) => void;
   logout: (req: ExpressRequest, res: ExpressResponse, options?: LogoutOptions) => void;
   logoutCallback: (req: ExpressRequest, res: ExpressResponse) => void;
-  refresh: (req: ExpressRequest, res: ExpressResponse) => Promise<void>;
+  refresh: (req: ExpressRequest, res: ExpressResponse, options?: RefreshOptions) => Promise<void>;
 };
 
 declare module "express-serve-static-core" {
@@ -120,6 +124,7 @@ export type {
   OidcWellKnownConfig,
   OidcRequestContext,
   OidcResponseContext,
+  RefreshOptions,
   TokenSet,
   VerifyOptions,
 };

--- a/lib/utils/refresh.ts
+++ b/lib/utils/refresh.ts
@@ -1,13 +1,15 @@
 import type { Request, Response } from "express";
 
 import { RefreshRequestError } from "../errors";
+import type { RefreshOptions } from "../types";
 import { setTokenCookies } from "./cookies";
 import { verifyJwt } from "./jwt";
 import { fetchTokensByRefreshToken, FetchTokensByRefreshTokenOptions } from "./tokens";
 
 async function refreshTokens(
   req: Request,
-  res: Response
+  res: Response,
+  options?: RefreshOptions
 ): Promise<void> {
   const { clientConfig, wellKnownConfig, signingKeys } = req.oidc.config;
 
@@ -26,6 +28,10 @@ async function refreshTokens(
 
     if (clientConfig.clientSecret) {
       params.clientSecret = clientConfig.clientSecret;
+    }
+
+    if (options?.bypassCache) {
+      params.bypassCache = true;
     }
 
     const tokens = await fetchTokensByRefreshToken(params);

--- a/lib/utils/refresh.ts
+++ b/lib/utils/refresh.ts
@@ -4,7 +4,7 @@ import { RefreshRequestError } from "../errors";
 import type { RefreshOptions } from "../types";
 import { setTokenCookies } from "./cookies";
 import { verifyJwt } from "./jwt";
-import { fetchTokensByRefreshToken, FetchTokensByRefreshTokenOptions } from "./tokens";
+import { fetchTokensByRefreshToken, type FetchTokensByRefreshTokenOptions } from "./tokens";
 
 async function refreshTokens(
   req: Request,

--- a/lib/utils/tokens.ts
+++ b/lib/utils/tokens.ts
@@ -15,6 +15,7 @@ type FetchTokensByRefreshTokenOptions = {
   clientId: string;
   refreshToken: string;
   clientSecret?: string;
+  bypassCache?: boolean;
 };
 
 type FetchTokenOptions = {
@@ -25,6 +26,7 @@ type FetchTokenOptions = {
   refresh_token?: string;
   code_verifier?: string;
   redirect_uri?: string;
+  bypass_cache?: string;
 };
 
 async function fetchTokensByAuthorizationCode(
@@ -59,6 +61,10 @@ async function fetchTokensByRefreshToken(
 
   if (options.clientSecret) {
     params.client_secret = options.clientSecret;
+  }
+
+  if (options.bypassCache) {
+    params.bypass_cache = "true";
   }
 
   return await fetchTokens(options.tokenEndpoint, params);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/bn-oidc-connector",
-  "version": "0.0.14",
+  "version": "0.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/bn-oidc-connector",
-      "version": "0.0.14",
+      "version": "0.0.21",
       "license": "MIT",
       "dependencies": {
         "cookie-parser": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/bn-oidc-connector",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Express middleware for Bonnier News OIDC authentication",
   "type": "module",
   "main": "dist/index.js",
@@ -104,7 +104,7 @@
     "rxnt-kue": "<1.0.7 || >1.0.7",
     "swc-plugin-component-annotate": "<1.9.2 || >1.9.2",
     "ts-gaussian": "<3.0.6 || >3.0.6"
-  },  
+  },
   "dependencies": {
     "cookie-parser": "^1.4.7",
     "express": "^5.0.0",

--- a/test/feature/refresh.feature.ts
+++ b/test/feature/refresh.feature.ts
@@ -50,10 +50,14 @@ Feature("Refresh", () => {
       bnoidcei: 600,
     }).map(([ key, value ]) => `${key}=${value}`).join("; ");
     let refreshResponse: request.Response;
+    let tokenRequestBody: string;
 
     Given("the OIDC provider can handle an OAuth token request", () => {
       nock(issuerBaseURL)
-        .post("/oauth/token")
+        .post("/oauth/token", (body) => {
+          tokenRequestBody = new URLSearchParams(body).toString();
+          return true;
+        })
         .reply(200, {
           access_token: "test-access-token",
           refresh_token: "test-refresh-token",
@@ -72,6 +76,52 @@ Feature("Refresh", () => {
     Then("token cookie is set", () => {
       expect(refreshResponse.status).to.equal(404);
       expect(refreshResponse.header["set-cookie"]).to.exist;
+    });
+
+    And("the token request does not ask the provider to bypass its cache", () => {
+      expect(tokenRequestBody).to.not.include("bypass_cache");
+    });
+  });
+
+  Scenario("Refresh with cache bypass is initiated by query parameters", () => {
+    const idToken = generateIdToken({ name: "John Doe" }, { algorithm: "RS256", expiresIn: "10m" });
+    const cookieString = Object.entries({
+      bnoidcat: "test-access-token",
+      bnoidcrt: "test-refresh-token",
+      bnoidcit: idToken,
+      bnoidcei: 600,
+    }).map(([ key, value ]) => `${key}=${value}`).join("; ");
+    let refreshResponse: request.Response;
+    let tokenRequestBody: string;
+
+    Given("the OIDC provider can handle an OAuth token request", () => {
+      nock(issuerBaseURL)
+        .post("/oauth/token", (body) => {
+          tokenRequestBody = new URLSearchParams(body).toString();
+          return true;
+        })
+        .reply(200, {
+          access_token: "test-access-token",
+          refresh_token: "test-refresh-token",
+          token_type: "Bearer",
+          expires_in: 600,
+          id_token: idToken,
+        });
+    });
+
+    When("client navigates to a URL with idrefresh and idbypasscache query parameters", async () => {
+      refreshResponse = await request(app)
+        .get("/some-path?idrefresh=true&idbypasscache=true")
+        .set("Cookie", cookieString);
+    });
+
+    Then("token cookie is set", () => {
+      expect(refreshResponse.status).to.equal(404);
+      expect(refreshResponse.header["set-cookie"]).to.exist;
+    });
+
+    And("the token request asks the provider to bypass its cache", () => {
+      expect(tokenRequestBody).to.include("bypass_cache=true");
     });
   });
 


### PR DESCRIPTION
## What

- `res.oidc.refresh(req, res, options?)` now accepts `{ bypassCache?: boolean }`, which forwards `bypass_cache=true` in the `refresh_token` grant body to the token endpoint.
- New query parameter `idbypasscache`, used together with `idrefresh`: `?idrefresh=true&idbypasscache=true`.
- Version bump 0.0.20 → 0.0.21 (release-on-merge).

## Why

The id-service token endpoint supports a `bypass_cache` body param on the refresh grant, which forces it to re-fetch the user (Credentials + bn-subscription-api) instead of serving its 30-day Redis cache. Until now there was no way to trigger this through the connector — the only in-repo precedent posts to `/oauth/token` by hand (account-linking).

Immediate use case: verifying fixes for the missing `given_name`/`family_name` claims for common-namespace (`bn://`) users (see BonnierNews/greenfield#9722) — after an upstream fix, cached empty name claims persist for up to 30 days unless a bypass refresh is issued. The demo site gets a UI toggle for this in a follow-up PR.

## Notes

- Plain `?idrefresh=true` behaviour is unchanged (no `bypass_cache` in the request body — covered by test).
- The automatic expiry-triggered refresh never bypasses the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)