### PR TITLE
fix: update request context claims and user after token refresh

### DIFF
--- a/lib/middleware/id-token.ts
+++ b/lib/middleware/id-token.ts
@@ -37,8 +37,8 @@ async function idToken(req: Request, res: Response, next: NextFunction) {
       // @todo We have to check if a refresh token exists
       await res.oidc.refresh(req, res);
 
-      // Decode the new ID token again after refresh
-      decodedJwt = decodeJwt(req.oidc.idToken, signingKeys, { issuer, audience });
+      // refreshTokens already verified the new ID token and attached its claims
+      decodedJwt = req.oidc.idTokenClaims;
 
       if (!decodedJwt) {
         throw new Error("Failed to decode ID token after refresh");

--- a/lib/middleware/id-token.ts
+++ b/lib/middleware/id-token.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 
-import type { OidcRequestContext } from "../types";
+import { attachUserToContext } from "../utils/claims";
 import { decodeJwt } from "../utils/jwt";
 
 // @todo This middleware should not be run for the login callback route!
@@ -56,15 +56,6 @@ async function idToken(req: Request, res: Response, next: NextFunction) {
   attachUserToContext(req, decodedJwt);
 
   next();
-}
-
-function attachUserToContext(req: Request, decodedJwt: Record<string, any>) {
-  const user: OidcRequestContext["user"] = {
-    id: decodedJwt.sub,
-    ...(decodedJwt.email && { email: decodedJwt.email }),
-  };
-
-  req.oidc.user = user;
 }
 
 export { idToken };

--- a/lib/utils/claims.ts
+++ b/lib/utils/claims.ts
@@ -1,5 +1,7 @@
 import type { Request } from "express";
 
+import type { OidcRequestContext } from "../types";
+
 function isUserEntitled(req: Request, validEntitlements: string[]): boolean {
   if (validEntitlements.length === 0) {
     return true;
@@ -9,4 +11,13 @@ function isUserEntitled(req: Request, validEntitlements: string[]): boolean {
   return validEntitlements.some((entitlement) => userEntitlements.includes(entitlement));
 }
 
-export { isUserEntitled };
+function attachUserToContext(req: Request, decodedJwt: Record<string, any>) {
+  const user: OidcRequestContext["user"] = {
+    id: decodedJwt.sub,
+    ...(decodedJwt.email && { email: decodedJwt.email }),
+  };
+
+  req.oidc.user = user;
+}
+
+export { attachUserToContext, isUserEntitled };

--- a/lib/utils/refresh.ts
+++ b/lib/utils/refresh.ts
@@ -2,8 +2,9 @@ import type { Request, Response } from "express";
 
 import { RefreshRequestError } from "../errors";
 import type { RefreshOptions } from "../types";
+import { attachUserToContext } from "./claims";
 import { setTokenCookies } from "./cookies";
-import { verifyJwt } from "./jwt";
+import { decodeJwt } from "./jwt";
 import { fetchTokensByRefreshToken, type FetchTokensByRefreshTokenOptions } from "./tokens";
 
 async function refreshTokens(
@@ -36,22 +37,25 @@ async function refreshTokens(
 
     const tokens = await fetchTokensByRefreshToken(params);
 
-    const validJwt = verifyJwt(tokens.idToken, signingKeys, {
+    const decodedJwt = decodeJwt(tokens.idToken, signingKeys, {
       issuer: wellKnownConfig.issuer,
       audience: clientConfig.clientId,
     });
 
-    if (!validJwt) {
+    if (!decodedJwt) {
       throw new Error("Failed to verify ID token");
     }
 
     setTokenCookies(clientConfig, res, tokens);
 
-    // Update the request context with new tokens
+    // Update the request context with new tokens and their claims, so the
+    // request that triggered the refresh already sees the refreshed identity
     req.oidc.accessToken = tokens.accessToken;
     req.oidc.refreshToken = tokens.refreshToken;
     req.oidc.idToken = tokens.idToken;
     req.oidc.expiresIn = tokens.expiresIn;
+    req.oidc.idTokenClaims = decodedJwt;
+    attachUserToContext(req, decodedJwt);
   } catch (error) {
     throw new RefreshRequestError(`Failed to refresh tokens: ${(error as Error).message.toLowerCase()}`);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/bn-oidc-connector",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/bn-oidc-connector",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "license": "MIT",
       "dependencies": {
         "cookie-parser": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/bn-oidc-connector",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Express middleware for Bonnier News OIDC authentication",
   "type": "module",
   "main": "dist/index.js",

--- a/test/feature/refresh.feature.ts
+++ b/test/feature/refresh.feature.ts
@@ -125,6 +125,48 @@ Feature("Refresh", () => {
     });
   });
 
+  Scenario("Request context reflects the refreshed claims on the same request", () => {
+    const oldIdToken = generateIdToken({ name: "John Doe", email: "old@example.com" }, { algorithm: "RS256", expiresIn: "10m" });
+    const newIdToken = generateIdToken({ name: "Jane Doe", email: "new@example.com" }, { algorithm: "RS256", expiresIn: "10m" });
+    const cookieString = Object.entries({
+      bnoidcat: "test-access-token",
+      bnoidcrt: "test-refresh-token",
+      bnoidcit: oldIdToken,
+      bnoidcei: 600,
+    }).map(([ key, value ]) => `${key}=${value}`).join("; ");
+    let contextResponse: request.Response;
+
+    Given("the OIDC provider can handle an OAuth token request", () => {
+      nock(issuerBaseURL)
+        .post("/oauth/token")
+        .reply(200, {
+          access_token: "new-test-access-token",
+          refresh_token: "new-test-refresh-token",
+          token_type: "Bearer",
+          expires_in: 600,
+          id_token: newIdToken,
+        });
+    });
+
+    And("there is an endpoint that echoes the request's OIDC context", () => {
+      app.get("/context-path", (req, res) => {
+        res.status(200).json({ claims: req.oidc.idTokenClaims, user: req.oidc.user });
+      });
+    });
+
+    When("client navigates to that endpoint with the idrefresh query parameter", async () => {
+      contextResponse = await request(app)
+        .get("/context-path?idrefresh=true")
+        .set("Cookie", cookieString);
+    });
+
+    Then("the response is built from the refreshed ID token's claims", () => {
+      expect(contextResponse.status).to.equal(200);
+      expect(contextResponse.body.claims.name).to.equal("Jane Doe");
+      expect(contextResponse.body.user.email).to.equal("new@example.com");
+    });
+  });
+
   Scenario("Refresh is triggered by an expired ID token", () => {
     const idToken = generateIdToken({ name: "John Doe" }, { algorithm: "RS256", expiresIn: "0m" });
     const cookieString = Object.entries({


### PR DESCRIPTION
## What

`refreshTokens()` now decodes the refreshed ID token and updates `req.oidc.idTokenClaims` + `req.oidc.user` along with the token fields (it previously only replaced `accessToken`/`refreshToken`/`idToken`/`expiresIn`). `attachUserToContext` moved from the id-token middleware to `utils/claims` so both call sites share it. `verifyJwt` → `decodeJwt` (which verifies then decodes) — no extra verification pass.

Version 0.0.21 → 0.0.22 (release-on-merge).

## Why

The id-token middleware decodes claims **before** the query-params middleware runs a `?idrefresh=true` refresh, so the request that triggered the refresh rendered the *previous* token's claims — e.g. the demo site's `/refresh` page showed stale `given_name`/`ent` until the next navigation. Spotted during browser verification of the bypass-cache flow (bn-login-monorepo#2086): after "Tokens refreshed with cache bypass", the page's "Current Claims" consistently lagged one token behind `/userinfo`.

## Notes

- The expiry-triggered refresh path in the id-token middleware already re-decoded after refresh; it now gets the values set twice (idempotent, unchanged behavior).
- New feature scenario: an endpoint echoing `req.oidc.idTokenClaims`/`user` hit with `?idrefresh=true` sees the **new** token's claims on that same request — fails without this fix.

## Tests

69 passing (1 new scenario), lint + typecheck + tsup build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)